### PR TITLE
Some fixes and cleanup

### DIFF
--- a/spec/sec-pattern-semantics-patch.html
+++ b/spec/sec-pattern-semantics-patch.html
@@ -92,11 +92,13 @@
           1. Let <del>_s_</del><ins>_r_</ins> be _cap_[_n_].
           1. If <del>_s_</del><ins>_r_</ins> is *undefined*, return _c_(_x_).
           1. Let _e_ be _x_'s _endIndex_.
-          1. Let _len_ be <del>the number of elements in _s_</del><ins>_r_._endIndex_ - _r_._startIndex_</ins>.
+          1. <ins>Let _rs_ be _r_'s _startIndex_.</ins>
+          1. <ins>Let _re_ be _r_'s _endIndex_.</ins>
+          1. Let _len_ be <del>the number of elements in _s_</del><ins>_re_ - _rs_</ins>.
           1. Let _f_ be _e_ + _direction_ &times; _len_.
           1. If _f_ &lt; 0 or _f_ &gt; _InputLength_, return ~failure~.
           1. Let _g_ be min(_e_, _f_).
-          1. If there exists an integer _i_ between 0 (inclusive) and _len_ (exclusive) such that Canonicalize(<del>_s_[_i_]</del><ins>_Input_[_r_._startIndex_ + _i_]</ins>) is not the same character value as Canonicalize(_Input_[_g_ + _i_]), return ~failure~.
+          1. If there exists an integer _i_ between 0 (inclusive) and _len_ (exclusive) such that Canonicalize(<del>_s_[_i_]</del><ins>_Input_[_rs_ + _i_]</ins>) is not the same character value as Canonicalize(_Input_[_g_ + _i_]), return ~failure~.
           1. Let _y_ be the State (_f_, _cap_).
           1. Call _c_(_y_) and return its result.
       </emu-alg>

--- a/spec/sec-properties-of-the-regexp-prototype-object-patch.html
+++ b/spec/sec-properties-of-the-regexp-prototype-object-patch.html
@@ -6,7 +6,7 @@
     
     <emu-clause id="sec-regexpbuiltinexec" aoid="RegExpBuiltinExec">
       <h1>Runtime Semantics: RegExpBuiltinExec ( _R_, _S_ )</h1>
-      <p>The abstract operation RegExpBuiltinExec with arguments _R_<del> and</del><ins>,</ins> _S_ <ins>and _matchOptions_</ins> performs the following steps:</p>
+      <p>The abstract operation RegExpBuiltinExec with arguments _R_ and _S_ performs the following steps:</p>
       <emu-alg>
         1. Assert: _R_ is an initialized RegExp instance.
         1. Assert: Type(_S_) is String.
@@ -48,15 +48,17 @@
         1. Perform ! CreateDataProperty(_A_, `"index"`, _lastIndex_).
         1. Perform ! CreateDataProperty(_A_, `"input"`, _S_).
         1. <del>Let _matchedSubstr_ be the matched substring (i.e. the portion of _S_ between offset _lastIndex_ inclusive and offset _e_ exclusive).</del>
-        1. <ins>Let _indices_ be the Record { [[Indices]]: &laquo; &raquo; }.</ins>
-        1. <ins>Let _match_ be the Match { [[StartIndex]]: _lastIndex_, [[EndIndex]]: _e_, [[GroupName]]: *undefined* }.</ins>
-        1. <ins>Add _match_ as the last element of _indices_.[[Indices]].</ins>
-        1. <ins>Let _matchedValue_ be ! GetMatchString(_S_, _match_)</ins>
+        1. <ins>Let _indices_ be &laquo; &raquo;.</ins>
+        1. <ins>Let _match_ be the Match { [[StartIndex]]: _lastIndex_, [[EndIndex]]: _e_ }.</ins>
+        1. <ins>Add _match_ as the last element of _indices_.</ins>
+        1. <ins>Let _matchedValue_ be ! GetMatchString(_S_, _match_).</ins>
         1. Perform ! CreateDataProperty(_A_, `"0"`, <del>_matchedSubstr_</del><ins>_matchedValue_</ins>).
         1. If _R_ contains any |GroupName|, then
           1. Let _groups_ be ObjectCreate(*null*).
+          1. <ins>Let _groupNames_ be &laquo; &raquo;.</ins>
         1. Else,
           1. Let _groups_ be *undefined*.
+          1. <ins>Let _groupNames_ be *undefined*.</ins>
         1. Perform ! CreateDataProperty(_A_, `"groups"`, _groups_).
         1. <ins>Let _getIndices_ be MakeGetIndices(_S_).</ins>
         1. <ins>Perform ! DefinePropertyOrThrow(_A_, `"indices"`, PropertyDescriptor { [[Get]]: _getIndices_, [[Set]]: *undefined*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).</ins>
@@ -69,29 +71,28 @@
           1. <del>Else _fullUnicode_ is *false*,</del>
             1. <del>Assert: _captureI_ is a List of code units.</del>
             1. <del>Let _capturedValue_ be the String value consisting of the code units of _captureI_.</del>
-          1. <ins>If the _i_th capture of _R_ was defined with a |GroupName|, then</ins>
-            1. <ins>Let _capturedGroup_ be the StringValue of the corresponding |RegExpIdentifierName|.</ins>
-          1. <ins>Else,</ins>
-            1. <ins>Let _capturedGroup_ be *undefined*.</ins>
           1. <ins>If _captureI_ is *undefined*, then</ins>
             1. <ins>Let _capturedValue_ be *undefined*.</ins>
-            1. <ins>Add *undefined* as the last element of _indices_.[[Indices]].</ins>
+            1. <ins>Add *undefined* as the last element of _indices_.</ins>
           1. <ins>Else,</ins>
             1. <ins>Let _captureStart_ be _captureI_'s _startIndex_.</ins>
             1. <ins>Let _captureEnd_ be _captureI_'s _endIndex_.</ins>
             1. <ins>If _fullUnicode_ is *true*, then</ins>
               1. <ins>Set _captureStart_ to ! GetStringIndex(_S_, _Input_, _captureStart_).</ins>
               1. <ins>Set _captureEnd_ to ! GetStringIndex(_S_, _Input_, _captureEnd_).</ins>
-            1. <ins>Let _capture_ be Match { [[StartIndex]]: _captureStart_, [[EndIndex]:: _captureEnd_, [[GroupName]]: _capturedGroup_ }.</ins>
-            1. <ins>Add _capture_ as the last element of _indices_.[[Indices]].</ins>
+            1. <ins>Let _capture_ be the Match { [[StartIndex]]: _captureStart_, [[EndIndex]:: _captureEnd_ }.</ins>
+            1. <ins>Add _capture_ as the last element of _indices_.</ins>
             1. <ins>Let _capturedValue_ be ! GetMatchString(_S_, _capture_).</ins>
           1. Perform ! CreateDataProperty(_A_, ! ToString(_i_), _capturedValue_).
-          1. <del>If the _i_th capture of _R_ was defined with a |GroupName|, then</del>
-            1. <del>Let _s_ be the StringValue of the corresponding |RegExpIdentifierName|.</del>
-            1. <del>Perform ! CreateDataProperty(_groups_, _s_, _capturedValue_).</del>
-          1. <ins>If _capturedGroup_ is not *undefined*, then</ins>
-            1. <ins>Perform ! CreateDataProperty(_groups_, _capturedGroup_, _capturedValue_).</ins>
+          1. If the _i_th capture of _R_ was defined with a |GroupName|, then
+            1. Let _s_ be the StringValue of the corresponding |RegExpIdentifierName|.
+            1. Perform ! CreateDataProperty(_groups_, _s_, _capturedValue_).
+            1. <ins>Assert: _groupNames_ is a List.</ins>
+            1. <ins>Add _s_ as the last element of _groupNames_.</ins>
+          1. <ins>Else,</ins>
+            1. <ins>If _groupNames_ is a List, add *undefined* as the last element of _groupNames_.</ins>
         1. <ins>Set _getIndices_.[[MatchIndices]] to _indices_.</ins>
+        1. <ins>Set _getIndices_.[[GroupNames]] to _groupNames_.</ins>
         1. Return _A_.
       </emu-alg>
     </emu-clause>
@@ -102,7 +103,7 @@
       <emu-alg>
         1. Assert: Type(_S_) is String.
         1. Assert: _Input_ is a List of the code points of _S_ interpreted as a UTF-16 encoded string.
-        1. Assert: _e_ is an integer index within _Input_.
+        1. Assert: _e_ is an integer value &ge; 0 and &lt; the number of elements in _Input_.
         1. Let _eUTF_ be the smallest index into _S_ that corresponds to the character at element _e_ of _Input_. If _e_ is greater than or equal to the number of elements in _Input_, then _eUTF_ is the number of code units in _S_.
         1. Return _eUTF_.
       </emu-alg>
@@ -114,8 +115,8 @@
       <emu-alg>
         1. Assert: Type(_S_) is String.
         1. Assert: _match_ is a Match Record.
-        1. Assert: _match_.[[StartIndex]] is an integer index into _S_.
-        1. Assert: _match_.[[EndIndex]] is an integer index into _S_ that is greater than or equal to _match_.[[StartIndex]].
+        1. Assert: _match_.[[StartIndex]] is an integer value &ge; 0 and &lt; the length of _S_.
+        1. Assert: _match_.[[EndIndex]] is an integer value &ge; _match_.[[StartIndex]] and &le; the length of _S_.
         1. Return the portion of _S_ between offset _match_.[[StartIndex]] inclusive and offset _match_.[[EndIndex]] exclusive.
       </emu-alg>
     </emu-clause>
@@ -126,8 +127,8 @@
       <emu-alg>
         1. Assert: Type(_S_) is String.
         1. Assert: _match_ is a Match Record.
-        1. Assert: _match_.[[StartIndex]] is an integer index into _S_.
-        1. Assert: _match_.[[EndIndex]] is an integer index into _S_ that is greater than or equal to _match_.[[StartIndex]].
+        1. Assert: _match_.[[StartIndex]] is an integer value &ge; 0 and &lt; the length of _S_.
+        1. Assert: _match_.[[EndIndex]] is an integer value &ge; _match_.[[StartIndex]] and &le; the length of _S_.
         1. Return CreateArrayFromList(&laquo; _match_.[[StartIndex]], _match_.[[EndIndex]] &raquo;).
       </emu-alg>
     </emu-clause>
@@ -138,13 +139,13 @@
       <emu-alg>
         1. Assert: Type(_S_) is String.
         1. Let _steps_ be the steps of a GetIndices function as specified below.
-        1. Let _getter_ be CreateBuiltinFunction(_steps_, &laquo; [[InputString]], [[MatchIndices]], [[MatchIndicesArray]] &raquo;).
+        1. Let _getter_ be CreateBuiltinFunction(_steps_, &laquo; [[InputString]], [[GroupNames]], [[MatchIndices]], [[MatchIndicesArray]] &raquo;).
         1. Set _getter_.[[InputString]] to _S_.
         1. Set _getter_.[[MatchIndicesArray]] to *undefined*.
         1. Return _getter_.
       </emu-alg>
 
-      <p>A <dfn>GetIndices</dfn> function is an anonymous built-in function with [[InputString]], [[MatchIndices]], and [[MatchIndicesArray]] internal slots. When a GetIndices function that expects no arguments is called it performs the following steps:</p>
+      <p>A <dfn>GetIndices</dfn> function is an anonymous built-in function with [[InputString]], [[GroupNames]], [[MatchIndices]], and [[MatchIndicesArray]] internal slots. When a GetIndices function that expects no arguments is called it performs the following steps:</p>
       <emu-alg>
         1. Let _f_ be the active function object.
         1. Let _A_ be _f_.[[MatchIndicesArray]].
@@ -153,24 +154,26 @@
         1. Let _S_ be _f_.[[InputString]].
         1. Let _indices_ be _f_.[[MatchIndices]].
         1. Assert: _indices_ is a List.
+        1. Let _groupNames_ be _f_.[[GroupNames]].
+        1. Assert: _groupNames_ is a List or is *undefined*.
         1. Let _n_ be the number of elements in _indices_.
         1. Assert: _n_ &lt; 2<sup>32</sup>-1.
         1. Set _A_ to ! ArrayCreate(_n_).
         1. Assert: The value of _A_'s `"length"` property is _n_.
-        1. If there exists an _element_ of _indices_ such that _element_ is a Match Record and _element_.[[GroupName]] is not *undefined*, then
+        1. If _groupNames_ is not *undefined*, then
           1. Let _groups_ be ! ObjectCreate(*null*).
         1. Else,
           1. Let _groups_ be *undefined*.
         1. Perform ! CreateDataProperty(_A_, `"groups"`, _groups_).
         1. For each integer _i_ such that _i_ &ge; 0 and _i_ &lt; _n_, do
-          1. Let _matchIndices_ be _i_<sup>th</sup> element of _indices_.
+          1. Let _matchIndices_ be _indices_[_i_].
           1. If _matchIndices_ is not *undefined*, then
             1. Let _matchIndicesArray_ be ! GetMatchIndicesArray(_S_, _matchIndices_).
-            1. If _matchIndices_.[[GroupName]] is not *undefined*, then
-              1. Perform ! CreateDataProperty(_groups_, _matchIndices_.[[GroupName]], _matchIndicesArray_).
           1. Else,
             1. Let _matchIndicesArray_ be *undefined*.
           1. Perform ! CreateDataProperty(_A_, ! ToString(_i_), _matchIndicesArray_).
+          1. If _groupNames_ is not *undefined* and _groupNames_[_i_] is not *undefined*, then
+            1. Perform ! CreateDataProperty(_groups_, _groupNames_[_i_], _matchIndicesArray_).
         1. Set _f_.[[MatchIndicesArray]] to _A_.
         1. Return _A_.
       </emu-alg>

--- a/spec/sec-properties-of-the-regexp-prototype-object-patch.html
+++ b/spec/sec-properties-of-the-regexp-prototype-object-patch.html
@@ -48,14 +48,14 @@
         1. Perform ! CreateDataProperty(_A_, `"index"`, _lastIndex_).
         1. Perform ! CreateDataProperty(_A_, `"input"`, _S_).
         1. <del>Let _matchedSubstr_ be the matched substring (i.e. the portion of _S_ between offset _lastIndex_ inclusive and offset _e_ exclusive).</del>
-        1. <ins>Let _indices_ be &laquo; &raquo;.</ins>
+        1. <ins>Let _indices_ be a new empty List.</ins>
         1. <ins>Let _match_ be the Match { [[StartIndex]]: _lastIndex_, [[EndIndex]]: _e_ }.</ins>
         1. <ins>Add _match_ as the last element of _indices_.</ins>
         1. <ins>Let _matchedValue_ be ! GetMatchString(_S_, _match_).</ins>
         1. Perform ! CreateDataProperty(_A_, `"0"`, <del>_matchedSubstr_</del><ins>_matchedValue_</ins>).
         1. If _R_ contains any |GroupName|, then
           1. Let _groups_ be ObjectCreate(*null*).
-          1. <ins>Let _groupNames_ be &laquo; &raquo;.</ins>
+          1. <ins>Let _groupNames_ be a new empty List.</ins>
         1. Else,
           1. Let _groups_ be *undefined*.
           1. <ins>Let _groupNames_ be *undefined*.</ins>
@@ -81,16 +81,16 @@
               1. <ins>Set _captureStart_ to ! GetStringIndex(_S_, _Input_, _captureStart_).</ins>
               1. <ins>Set _captureEnd_ to ! GetStringIndex(_S_, _Input_, _captureEnd_).</ins>
             1. <ins>Let _capture_ be the Match { [[StartIndex]]: _captureStart_, [[EndIndex]:: _captureEnd_ }.</ins>
-            1. <ins>Add _capture_ as the last element of _indices_.</ins>
+            1. <ins>Append _capture_ to _indices_.</ins>
             1. <ins>Let _capturedValue_ be ! GetMatchString(_S_, _capture_).</ins>
           1. Perform ! CreateDataProperty(_A_, ! ToString(_i_), _capturedValue_).
           1. If the _i_th capture of _R_ was defined with a |GroupName|, then
             1. Let _s_ be the StringValue of the corresponding |RegExpIdentifierName|.
             1. Perform ! CreateDataProperty(_groups_, _s_, _capturedValue_).
             1. <ins>Assert: _groupNames_ is a List.</ins>
-            1. <ins>Add _s_ as the last element of _groupNames_.</ins>
+            1. <ins>Append _s_ to _groupNames_.</ins>
           1. <ins>Else,</ins>
-            1. <ins>If _groupNames_ is a List, add *undefined* as the last element of _groupNames_.</ins>
+            1. <ins>If _groupNames_ is a List, append *undefined* to _groupNames_.</ins>
         1. <ins>Set _getIndices_.[[MatchIndices]] to _indices_.</ins>
         1. <ins>Set _getIndices_.[[GroupNames]] to _groupNames_.</ins>
         1. Return _A_.

--- a/spec/sec-regexp-abstract-operations-patch.html
+++ b/spec/sec-regexp-abstract-operations-patch.html
@@ -4,7 +4,7 @@
   <emu-clause id="sec-match-records">
     <h1><ins>Match Records</ins></h1>
     <ins>
-    <p>A <dfn>Match</dfn> is a Record value used to encapsulate the start and end indices of a regular expression match along with any associated capture group name.</p>
+    <p>A <dfn>Match</dfn> is a Record value used to encapsulate the start and end indices of a regular expression match or capture.</p>
     <p>Match Records have the fields listed in <emu-xref href="#table-match-record"></emu-xref>.</p>
     </ins>
     <emu-table id="table-match-record" caption="Match Record Fields">
@@ -24,11 +24,6 @@
             <td>[[EndIndex]]</td>
             <td>An integer &ge; [[StartIndex]].</td>
             <td>The number of code units from the start of a string at which the match ends (exclusive).</td>
-          </tr>
-          <tr>
-            <td>[[GroupName]]</td>
-            <td>A String or *undefined*.</td>
-            <td>An associated group name if the match belongs to a named capture group.</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
While drafting the PR for tc39/ecma262 I notices a few issues in the proposal that I'd like to have reviewed:

- In BackreferenceMatcher: `_r_._startIndex_` and `_r_._endIndex_` do not seem to be the correct way to reference these values.
- In RegExpBuiltinExec: There was a leftover reference to `_matchOptions_` that had not been removed.
- In RegExpBuiltinExec: `_indices_` was still incorrectly defined as a Record when it should have been a List.
- Cleaned up Asserts in GetStringIndex, GetMatchString, GetMatchIndicesArray
- In MakeGetIndices: The `"groups"` property on the `"indices"` array result is not being created in the same way as the `"groups"` property on the result of RegExpBuiltinExec:
  - `result.groups` always exists if there is a _GroupName_ production in the pattern, but `result.indices.groups` only exists if there was a successful capture in a named capture group.
  - `result.groups[name]` always exists (but may be `undefined`) for every _GroupName_ in the pattern, but `result.indices.groups[name]` only exists if there was a successful capture in a named capture group.
  - Addressed this by providing the group names for each possible capture group as a `[[GroupNames]]` internal slot on the `"indices"` getter and removing the `[[GroupName]]` field from the Match Record.
- In MakeGetIndices: The loop used the prose `the _i_<sup>th</sup> element of _indices_`, which is incorrect and introduces an off-by-one error as the spec stats that the `_i_th` element of `_x_` is equivalent to `_x_[_i_ - 1]` (i.e. `The 1st element of _x_` refers to `_x_[0]`).

Rendered Spec: https://tc39.es/proposal-regexp-match-indices/pr/27